### PR TITLE
fix(tsconfig): drop deprecated baseUrl for TypeScript 6 compatibility

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -14,7 +14,6 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "exactOptionalPropertyTypes": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     },


### PR DESCRIPTION
## What

Drop the now-deprecated `baseUrl` option from `tsconfig.app.json`. The existing path mapping (`"@/*": ["./src/*"]`) keeps working because TypeScript resolves `paths` relative to the tsconfig's own directory when `baseUrl` is absent.

## Why

TypeScript 6 raises `TS5101: Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0` for this entry. The dependabot build-tooling bump (#24) hits this and the Typecheck job fails.

This change unblocks #24 — once merged, re-running `@dependabot rebase` on that PR should turn it green.

## Verification

| Check | Result |
| --- | --- |
| `pnpm typecheck` | clean |
| `pnpm test` | 18 / 18 |
| `pnpm build` | clean |
| `pnpm lint` | clean |

## Test plan

- [ ] CI green on this PR (still on TS 5.9)
- [ ] After merge, `@dependabot rebase` on #24, expect Typecheck to pass on TS 6.0.3