### PR TITLE
feat: mark discontinued services with shutdown date and badge

### DIFF
--- a/info.json
+++ b/info.json
@@ -324,7 +324,8 @@
     "img": "alexa.png",
     "nationality": "United-States-of-America",
     "description": "ウェブサイトの利用状況に関するデータを集め、ウェブサイトがどれだけの人に見られているかを調査している。alexa.comでは、ドメインへの1日当たりのアクセス数や訪問者数、直帰率、世界および国内におけるランキングなどを確認できる。なお、Alexa InternetはWayback Machineのデータ提供元でもある",
-    "description_en": "Collects data on website usage and investigates how many people view websites. At alexa.com, you can check the number of accesses and visitors per day to a domain, bounce rate, and rankings in the world and domestically. Alexa Internet is also a data provider for the Wayback Machine."
+    "description_en": "Collects data on website usage and investigates how many people view websites. At alexa.com, you can check the number of accesses and visitors per day to a domain, bounce rate, and rankings in the world and domestically. Alexa Internet is also a data provider for the Wayback Machine.",
+    "ended": "2022-05-01"
   },
   {
     "date": "1996",
@@ -1378,7 +1379,8 @@
     "img": "sixdegrees.jpg",
     "nationality": "United-States-of-America",
     "description": "1997年〜2001年に運営されていたサイトです。サービス名である「Six degress」とは、自分の知り合いを6人たどれば、全世界中の人と連絡が取れるという「Six Degrees of Separations」（6次の隔たり）理論に由来しています。「6次の隔たり」はSNSにとっては重要な要素であり、日本SNSサイト「Gree」はこの「Six Degrees of Separations」から命名されています。",
-    "description_en": "A site operated from 1997 to 2001. The service name \"Six Degrees\" is derived from the \"Six Degrees of Separation\" theory that if you trace 6 acquaintances, you can contact anyone in the world. \"Six degrees of separation\" is an important element for SNS, and the Japanese SNS site \"Gree\" is named after this \"Six Degrees of Separation\"."
+    "description_en": "A site operated from 1997 to 2001. The service name \"Six Degrees\" is derived from the \"Six Degrees of Separation\" theory that if you trace 6 acquaintances, you can contact anyone in the world. \"Six degrees of separation\" is an important element for SNS, and the Japanese SNS site \"Gree\" is named after this \"Six Degrees of Separation\".",
+    "ended": "2001"
   },
   {
     "date": "2004-02-21",
@@ -1575,7 +1577,8 @@
     "img": "pandoratv.png",
     "nationality": "Korea,-South",
     "description": "かつては著作権問題を抱えていたが、韓国国内では著作権問題は解決している。また青瓦台や警察庁など行政機関が、パンドラTVを使った定例記者会見映像や広報映像の配信を行ったり、ケーブルテレビ局との提携による番組配信、著作権者の許可を得て『NARUTO -ナルト-』・『攻殻機動隊』・『BLEACH』などのアニメ作品を放映しているが、明らかに無許可の日本アニメやドラマなどもアップロードされ続けている。日本国内では24時間モニタリングされ、違法または問題となるコンテンツがアップされたら削除するようにしている。",
-    "description_en": "It used to have copyright issues, but copyright issues have been resolved within South Korea. Also, administrative agencies such as the Blue House and the National Police Agency distribute regular press conference videos and promotional videos using Pandora TV, distribute programs through partnerships with cable TV stations, and broadcast anime works such as \"NARUTO\", \"Ghost in the Shell\", and \"BLEACH\" with the permission of copyright holders, but obviously unauthorized Japanese anime and dramas continue to be uploaded. In Japan, it is monitored 24 hours a day, and illegal or problematic content is deleted if uploaded."
+    "description_en": "It used to have copyright issues, but copyright issues have been resolved within South Korea. Also, administrative agencies such as the Blue House and the National Police Agency distribute regular press conference videos and promotional videos using Pandora TV, distribute programs through partnerships with cable TV stations, and broadcast anime works such as \"NARUTO\", \"Ghost in the Shell\", and \"BLEACH\" with the permission of copyright holders, but obviously unauthorized Japanese anime and dramas continue to be uploaded. In Japan, it is monitored 24 hours a day, and illegal or problematic content is deleted if uploaded.",
+    "ended": "2023-01-31"
   },
   {
     "date": "2016-09",
@@ -1601,7 +1604,8 @@
     "img": "liveleak.png",
     "nationality": "United-States-of-America",
     "description": "戦争・テロ・犯罪・事故・災害といった現実の出来事を生のまま配信するニュース／ショックサイトの代表格。2006年に競合のOgrish.comを統合し、市民ジャーナリズムと「グロサイト」の中間を占めた。2021年5月5日にサービスを終了し、ItemFix.comへリダイレクトされた。",
-    "description_en": "News / shock site that distributed raw footage of wars, terrorism, crimes, accidents, and disasters. Absorbed competitor Ogrish.com in 2006, occupying a contested space between citizen journalism and outright shock content. Shut down on May 5, 2021 and redirected to ItemFix.com."
+    "description_en": "News / shock site that distributed raw footage of wars, terrorism, crimes, accidents, and disasters. Absorbed competitor Ogrish.com in 2006, occupying a contested space between citizen journalism and outright shock content. Shut down on May 5, 2021 and redirected to ItemFix.com.",
+    "ended": "2021-05-05"
   },
   {
     "date": "2014-06-06",
@@ -2436,7 +2440,8 @@
     "img": "napster.svg",
     "nationality": "United-States-of-America",
     "description": "ショーン・ファニングらが開発したP2Pファイル共有サービス。MP3音楽ファイルの無料共有を可能にし、音楽業界に激震を走らせた。著作権侵害訴訟により閉鎖されたが、その技術と概念は後のストリーミング時代への道を開いた。",
-    "description_en": "A P2P file-sharing service developed by Shawn Fanning and others. It enabled free sharing of MP3 music files, shaking the music industry. Although shut down due to copyright lawsuits, its technology and concept paved the way for the streaming era."
+    "description_en": "A P2P file-sharing service developed by Shawn Fanning and others. It enabled free sharing of MP3 music files, shaking the music industry. Although shut down due to copyright lawsuits, its technology and concept paved the way for the streaming era.",
+    "ended": "2001-07-11"
   },
   {
     "date": "1981-07-02",
@@ -2475,7 +2480,8 @@
     "img": "megaupload.svg",
     "nationality": "Hong-Kong",
     "description": "キム・ドットコムによって設立されたオンラインストレージサービス。手軽なファイル共有手段として絶大な人気を誇ったが、大規模な著作権侵害の温床としてFBIにより閉鎖され、経営陣が逮捕された。",
-    "description_en": "An online storage service founded by Kim Dotcom. While immensely popular for easy file sharing, it was shut down by the FBI and its executives arrested for facilitating massive copyright infringement."
+    "description_en": "An online storage service founded by Kim Dotcom. While immensely popular for easy file sharing, it was shut down by the FBI and its executives arrested for facilitating massive copyright infringement.",
+    "ended": "2012-01-19"
   },
   {
     "date": "2000-05-03",
@@ -2488,7 +2494,8 @@
     "img": "limewire.svg",
     "nationality": "United-States-of-America",
     "description": "マーク・ゴートンによって開発されたP2Pファイル共有ソフト。Gnutellaネットワークを利用し、Napster後のファイル共有ブームを支えたが、RIAA（全米レコード協会）との訴訟に敗れ、サービスを停止した。",
-    "description_en": "A P2P file-sharing client developed by Mark Gorton. Using the Gnutella network, it sustained the file-sharing boom after Napster but ceased operations after losing a lawsuit against the RIAA."
+    "description_en": "A P2P file-sharing client developed by Mark Gorton. Using the Gnutella network, it sustained the file-sharing boom after Napster but ceased operations after losing a lawsuit against the RIAA.",
+    "ended": "2010-10-26"
   },
   {
     "date": "2011-09-05",
@@ -2514,7 +2521,8 @@
     "img": "popcorntime.svg",
     "nationality": "Argentina",
     "description": "アルゼンチンの開発者グループによって作成された、オープンソースのBitTorrentクライアント。「海賊版のNetflix」とも呼ばれ、ダウンロードを待たずにストリーミング再生できる画期的なUXで人気を博した。",
-    "description_en": "An open-source BitTorrent client created by a group of developers from Argentina. Often called the \"Netflix of piracy,\" it gained popularity for its revolutionary UX that allowed streaming without waiting for downloads."
+    "description_en": "An open-source BitTorrent client created by a group of developers from Argentina. Often called the \"Netflix of piracy,\" it gained popularity for its revolutionary UX that allowed streaming without waiting for downloads.",
+    "ended": "2022-01-05"
   },
   {
     "date": "2016-01-01",
@@ -2527,7 +2535,8 @@
     "img": "mangamura.svg",
     "nationality": "Japan",
     "description": "星野ロミによって運営されていた、日本最大級の海賊版マンガ閲覧サイト。出版業界に甚大な被害を与え、社会問題化。政府によるサイトブロッキング議論の引き金となり、運営者の逮捕と実刑判決に至った。",
-    "description_en": "Japan's largest pirate manga viewing site, operated by Romi Hoshino. It caused immense damage to the publishing industry and became a social issue, triggering debates on site blocking and leading to the arrest and imprisonment of the operator."
+    "description_en": "Japan's largest pirate manga viewing site, operated by Romi Hoshino. It caused immense damage to the publishing industry and became a social issue, triggering debates on site blocking and leading to the arrest and imprisonment of the operator.",
+    "ended": "2018-04-17"
   },
   {
     "date": "2002-05-06",
@@ -2566,7 +2575,8 @@
     "img": "silkroad.svg",
     "nationality": "United-States-of-America",
     "description": "ロス・ウルブリヒト（ドレッド・パイレート・ロバーツ）によって開設された、最初の現代的なダークネットマーケット。Torによる匿名性とBitcoinによる決済を組み合わせ、違法薬物などの取引を可能にした。",
-    "description_en": "The first modern darknet market, founded by Ross Ulbricht (Dread Pirate Roberts). It combined Tor's anonymity with Bitcoin payments to enable the trade of illegal drugs and other goods."
+    "description_en": "The first modern darknet market, founded by Ross Ulbricht (Dread Pirate Roberts). It combined Tor's anonymity with Bitcoin payments to enable the trade of illegal drugs and other goods.",
+    "ended": "2013-10-02"
   },
   {
     "date": "2000-03-01",
@@ -2605,7 +2615,8 @@
     "img": "alphabay.svg",
     "nationality": "Canada",
     "description": "アレクサンドル・カゼスによって設立された、Silk Road閉鎖後の最大規模のダークネットマーケット。2017年に法執行機関によって閉鎖されるまで、数多くの違法取引が行われていた。",
-    "description_en": "The largest darknet market after the closure of Silk Road, founded by Alexandre Cazes. It hosted numerous illegal transactions until it was shut down by law enforcement in 2017."
+    "description_en": "The largest darknet market after the closure of Silk Road, founded by Alexandre Cazes. It hosted numerous illegal transactions until it was shut down by law enforcement in 2017.",
+    "ended": "2017-07-04"
   },
   {
     "date": "1969-10-29",
@@ -2735,7 +2746,8 @@
     "img": "theranos.svg",
     "nationality": "United-States-of-America",
     "description": "エリザベス・ホームズによって設立された医療ベンチャー。「数滴の血液で数百種類の検査ができる」と謳い巨額の資金を集めたが、技術は実在せず、シリコンバレー史上最大級の詐欺事件として崩壊した。",
-    "description_en": "A health tech startup founded by Elizabeth Holmes. It raised massive funds claiming to run hundreds of tests with a few drops of blood, but the technology didn't exist, leading to one of Silicon Valley's biggest frauds."
+    "description_en": "A health tech startup founded by Elizabeth Holmes. It raised massive funds claiming to run hundreds of tests with a few drops of blood, but the technology didn't exist, leading to one of Silicon Valley's biggest frauds.",
+    "ended": "2018-09-04"
   },
   {
     "date": "2010-07-18",
@@ -2748,7 +2760,8 @@
     "img": "mtgox.svg",
     "nationality": "Japan",
     "description": "かつて世界最大のビットコイン取引所だった東京の企業。2014年に約85万BTC（当時のレートで約480億円）が消失し破綻。仮想通貨のセキュリティと規制の重要性を世界に知らしめた事件。",
-    "description_en": "Once the world's largest Bitcoin exchange, based in Tokyo. It collapsed in 2014 after losing about 850,000 BTC, highlighting the critical need for security and regulation in cryptocurrency."
+    "description_en": "Once the world's largest Bitcoin exchange, based in Tokyo. It collapsed in 2014 after losing about 850,000 BTC, highlighting the critical need for security and regulation in cryptocurrency.",
+    "ended": "2014-02-28"
   },
   {
     "date": "1970-07-01",
@@ -3339,8 +3352,9 @@
     ],
     "img": "sora.svg",
     "nationality": "United-States-of-America",
-    "description": "OpenAIが2024年2月15日に研究プレビューを発表し、12月9日にChatGPT Plus/Pro加入者向けに一般公開した動画生成AI。テキストから最長1分の高品質動画を生成し、映像制作のワークフローに大きな衝撃を与えた。",
-    "description_en": "OpenAI's video-generation model: research preview announced February 15, 2024, public release for ChatGPT Plus/Pro on December 9, 2024. Generates up to one-minute high-quality videos from text, reshaping creative workflows."
+    "description": "OpenAIが2024年2月15日に研究プレビューを発表し、12月9日にChatGPT Plus/Pro加入者向けに一般公開した動画生成AI。テキストから最長1分の高品質動画を生成し、映像制作のワークフローに大きな衝撃を与えた。しかし運用コストの高騰や著作権・ディープフェイク問題を受け、2026年4月26日にWeb版・アプリ版（sora.com及びiOS/Androidアプリ）が提供終了。API版も2026年9月24日に終了予定で、スタンドアロン製品としてのSoraは幕を下ろした。",
+    "description_en": "OpenAI's video-generation model: research preview announced February 15, 2024, public release for ChatGPT Plus/Pro on December 9, 2024. Generates up to one-minute high-quality videos from text, reshaping creative workflows. Amid soaring compute costs and copyright/deepfake controversies, the Sora web and app experiences (sora.com and the iOS/Android apps) were discontinued on April 26, 2026, with the API to follow on September 24, 2026 — ending Sora as a standalone product.",
+    "ended": "2026-04-26"
   },
   {
     "date": "2025-04-05",

--- a/info.json
+++ b/info.json
@@ -1364,7 +1364,8 @@
     "img": "friendster.png",
     "nationality": "Canada",
     "description": "まだMyspace（2003年開始）、Facebook（2004年開始）が無く、他のソーシャル・ネットワーキング・サイトも広く使われる前の[14]2002年、Friendsterはカナダのコンピュータプログラマーであるジョナサン・エイブラムスが設立した[15]。Pets.com（1997年開始）のようなその他いくつかの小規模なソーシャル・ネットワーキング・サイトが先行していた中でFriendsterは会員数が100万人に達したサイトの一角になるまで成長した。",
-    "description_en": "In 2002, before Myspace (started in 2003) and Facebook (started in 2004) existed and other social networking sites were widely used, Friendster was founded by Canadian computer programmer Jonathan Abrams. While several other small social networking sites such as Pets.com (started in 1997) preceded it, Friendster grew to become one of the sites with 1 million members."
+    "description_en": "In 2002, before Myspace (started in 2003) and Facebook (started in 2004) existed and other social networking sites were widely used, Friendster was founded by Canadian computer programmer Jonathan Abrams. While several other small social networking sites such as Pets.com (started in 1997) preceded it, Friendster grew to become one of the sites with 1 million members.",
+    "ended": "2015-06-30"
   },
   {
     "date": "1997",
@@ -1429,7 +1430,8 @@
     "img": "skype.svg",
     "nationality": "Estonia",
     "description": "ニコラス・センストロムとヤヌス・フリスが2003年に設立したP2P電話サービス。スマートフォン以前の国際通話の常識を変えた。2011年5月、Microsoftが85億ドルで買収。長らくMicrosoftのコミュニケーション基盤として使われてきたが、2025年5月5日にコンシューマー版サービスを終了し、ユーザーはMicrosoft Teams（無料版）へ移行した。",
-    "description_en": "P2P calling service founded in 2003 by Niklas Zennström and Janus Friis, transforming international phone calls before the smartphone era. Acquired by Microsoft for $8.5B in May 2011. The consumer service shut down on May 5, 2025, with users migrated to the free tier of Microsoft Teams."
+    "description_en": "P2P calling service founded in 2003 by Niklas Zennström and Janus Friis, transforming international phone calls before the smartphone era. Acquired by Microsoft for $8.5B in May 2011. The consumer service shut down on May 5, 2025, with users migrated to the free tier of Microsoft Teams.",
+    "ended": "2025-05-05"
   },
   {
     "date": "2004-09-15",
@@ -1494,7 +1496,8 @@
     "img": "googleplus.svg",
     "nationality": "United-States-of-America",
     "description": "2011年6月、プロジェクトに1年間を費やした末にサービスが開始された。Googleでは新サービスの船出を記念して、プロジェクトに携わった数百人の従業員に水兵帽を配った。2018年12月10日には米グーグル社がGoogle+ APIに個人情報が漏洩する可能性があるバグが存在していたことを発表し、Google+の個人向けサービスを2019年4月に4ヶ月前倒しして終了すると発表した。同社は個人情報を不正に取得された形跡はないとしている。",
-    "description_en": "Service started in June 2011 after spending a year on the project. Google distributed sailor hats to hundreds of employees involved in the project to commemorate the launch of the new service. On December 10, 2018, Google announced that there was a bug in the Google+ API that could leak personal information, and announced that the consumer service of Google+ would be terminated in April 2019, four months ahead of schedule. The company stated that there was no evidence that personal information was acquired illegally."
+    "description_en": "Service started in June 2011 after spending a year on the project. Google distributed sailor hats to hundreds of employees involved in the project to commemorate the launch of the new service. On December 10, 2018, Google announced that there was a bug in the Google+ API that could leak personal information, and announced that the consumer service of Google+ would be terminated in April 2019, four months ahead of schedule. The company stated that there was no evidence that personal information was acquired illegally.",
+    "ended": "2019-04-02"
   },
   {
     "date": "1990",
@@ -2797,7 +2800,8 @@
     "img": "geocities.svg",
     "nationality": "United-States-of-America",
     "description": "デイビッド・ボネットらが設立した、無料ウェブホスティングサービス。ユーザーが「近所（Neighborhoods）」と呼ばれるテーマ別のコミュニティにホームページを作成できる仕組みで、個人サイトブームを巻き起こした。2009年に米国でのサービスを終了。",
-    "description_en": "A free web hosting service founded by David Bohnett and others. It sparked a personal website boom by allowing users to create homepages in themed communities called \"Neighborhoods\". US service ended in 2009."
+    "description_en": "A free web hosting service founded by David Bohnett and others. It sparked a personal website boom by allowing users to create homepages in themed communities called \"Neighborhoods\". US service ended in 2009.",
+    "ended": "2009-10-26"
   },
   {
     "date": "1969-01-01",
@@ -2901,7 +2905,8 @@
     "img": "googlereader.svg",
     "nationality": "United-States-of-America",
     "description": "GoogleがChris Wetherellを中心に開発したRSSフィードリーダー。2005年10月の公開後、RSS文化の中心的存在となったが、2013年7月1日にサービス終了。代替サービス（Feedly等）への移行を促す形でRSSコミュニティに大きな影響を残した。",
-    "description_en": "Google's RSS feed reader, launched October 2005, became the de facto center of RSS culture before its shutdown on July 1, 2013, prompting an exodus to Feedly and similar services."
+    "description_en": "Google's RSS feed reader, launched October 2005, became the de facto center of RSS culture before its shutdown on July 1, 2013, prompting an exodus to Feedly and similar services.",
+    "ended": "2013-07-01"
   },
   {
     "date": "2007-06-01",
@@ -2929,7 +2934,8 @@
     "img": "googlewave.svg",
     "nationality": "United-States-of-America",
     "description": "Googleが2009年のGoogle I/Oで発表したリアルタイム共同編集ツール。メール・チャット・ドキュメント・Wikiを統合する野心的な構想で大きな話題を呼んだが、ユーザー獲得に失敗し、2010年8月に開発中止が発表され、2012年4月30日に完全終了した。",
-    "description_en": "Real-time collaboration platform announced at Google I/O 2009, ambitiously merging email, chat, docs, and wikis. Failed to gain traction; development halted August 2010 and the service shut down on April 30, 2012."
+    "description_en": "Real-time collaboration platform announced at Google I/O 2009, ambitiously merging email, chat, docs, and wikis. Failed to gain traction; development halted August 2010 and the service shut down on April 30, 2012.",
+    "ended": "2012-04-30"
   },
   {
     "date": "2015-11-01",
@@ -2970,7 +2976,8 @@
     "img": "stadia.svg",
     "nationality": "United-States-of-America",
     "description": "Googleが2019年11月19日に14か国で開始したクラウドゲーミングサービス。専用コントローラーやChromecast上での4K・60fpsストリーミングを売りにしたが、独占タイトルの不足やビジネスモデルの誤算で苦戦し、2023年1月18日にサービス終了。Googleがハードウェア事業の難しさを露呈した象徴的事例。",
-    "description_en": "Cloud gaming service launched by Google on November 19, 2019 in 14 countries, promising 4K/60fps streaming on Chromecast. Hampered by a lack of exclusives and business-model missteps, it shut down on January 18, 2023 — a high-profile cautionary tale for Google's hardware ambitions."
+    "description_en": "Cloud gaming service launched by Google on November 19, 2019 in 14 countries, promising 4K/60fps streaming on Chromecast. Hampered by a lack of exclusives and business-model missteps, it shut down on January 18, 2023 — a high-profile cautionary tale for Google's hardware ambitions.",
+    "ended": "2023-01-18"
   },
   {
     "date": "2020-05-13",
@@ -3515,7 +3522,8 @@
     "img": "vine.svg",
     "nationality": "United-States-of-America",
     "description": "2013年1月24日にiOSで公開された6秒ループ動画の共有アプリ。短尺動画文化の元祖としてTikTok以前の時代を象徴し、Twitterに買収された。",
-    "description_en": "A six-second looping video app launched on iOS on January 24, 2013. A pioneer of short-form video culture before TikTok, it was acquired by Twitter."
+    "description_en": "A six-second looping video app launched on iOS on January 24, 2013. A pioneer of short-form video culture before TikTok, it was acquired by Twitter.",
+    "ended": "2017-01-17"
   },
   {
     "date": "2016-03-16",

--- a/scripts/mark-ended.mjs
+++ b/scripts/mark-ended.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 /**
  * Mark discontinued services with their shutdown date.
- * Adds an optional `ended` field (ISO date) to existing info.json entries.
- * Re-runnable: each listed entry is overwritten; others are left untouched.
+ * The ENDED map below is the single source of truth: listed entries get the
+ * `ended` ISO date set, and the field is removed from any entry not listed
+ * (e.g. a service that was resurrected or marked by mistake). Fully idempotent.
  */
 import { readFileSync, writeFileSync } from "node:fs"
 import { resolve } from "node:path"
@@ -37,13 +38,17 @@ const ENDED = {
 }
 
 let updated = 0
+let cleared = 0
 for (const item of items) {
   const ended = ENDED[item.name]
   if (ended) {
     item.ended = ended
     updated++
+  } else if ("ended" in item) {
+    delete item.ended
+    cleared++
   }
 }
 
 writeFileSync(path, `${JSON.stringify(items, null, 2)}\n`)
-console.log(`✓ Ended markers applied: ${updated}/${Object.keys(ENDED).length}`)
+console.log(`✓ Ended markers applied: ${updated}/${Object.keys(ENDED).length} (cleared ${cleared})`)

--- a/scripts/mark-ended.mjs
+++ b/scripts/mark-ended.mjs
@@ -20,6 +20,20 @@ const ENDED = {
   Skype: "2025-05-05",
   Stadia: "2023-01-18",
   "Google Wave": "2012-04-30",
+  Mangamura: "2018-04-17",
+  Sora: "2026-04-26",
+  "Alexa Internet": "2022-05-01",
+  "Pandora TV": "2023-01-31",
+  Theranos: "2018-09-04",
+  Megaupload: "2012-01-19",
+  LimeWire: "2010-10-26",
+  "Silk Road": "2013-10-02",
+  AlphaBay: "2017-07-04",
+  "SixDegrees.com": "2001",
+  "Mt. Gox": "2014-02-28",
+  LiveLeak: "2021-05-05",
+  Napster: "2001-07-11",
+  "Popcorn Time": "2022-01-05",
 }
 
 let updated = 0

--- a/scripts/mark-ended.mjs
+++ b/scripts/mark-ended.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+/**
+ * Mark discontinued services with their shutdown date.
+ * Adds an optional `ended` field (ISO date) to existing info.json entries.
+ * Re-runnable: each listed entry is overwritten; others are left untouched.
+ */
+import { readFileSync, writeFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+const path = resolve(process.cwd(), "info.json")
+const items = JSON.parse(readFileSync(path, "utf8"))
+
+// name -> shutdown date (ISO). Only services that are fully discontinued.
+const ENDED = {
+  "Google Reader": "2013-07-01",
+  "Google+": "2019-04-02",
+  Vine: "2017-01-17",
+  GeoCities: "2009-10-26",
+  Friendster: "2015-06-30",
+  Skype: "2025-05-05",
+  Stadia: "2023-01-18",
+  "Google Wave": "2012-04-30",
+}
+
+let updated = 0
+for (const item of items) {
+  const ended = ENDED[item.name]
+  if (ended) {
+    item.ended = ended
+    updated++
+  }
+}
+
+writeFileSync(path, `${JSON.stringify(items, null, 2)}\n`)
+console.log(`✓ Ended markers applied: ${updated}/${Object.keys(ENDED).length}`)

--- a/src/App.vue
+++ b/src/App.vue
@@ -20,6 +20,11 @@ import AppHeader from "@/components/Header.vue"
   --header-bg: light-dark(rgba(255, 255, 255, 0.85), rgba(10, 10, 10, 0.85));
   --flag-border: light-dark(#eeeeee, #2a2a2a);
   --logo-bg: light-dark(transparent, #ffffff);
+  --ended-bg: light-dark(#fbf7f9, #221c20);
+  --ended-badge-bg: light-dark(#ffe3ef, #4a2438);
+  --ended-badge-text: light-dark(#8a3b63, #ffd9e8);
+  --ended-badge-border: light-dark(#e58bb0, #b56c8c);
+  --ended-badge-shadow: light-dark(#e58bb0, #00000055);
   --accent-color: var(--text-color);
   --border-width: 2px;
   --border-radius: 8px;

--- a/src/components/Birth.vue
+++ b/src/components/Birth.vue
@@ -187,7 +187,7 @@ function count(tag: string): number {
             :class="['filter-chip', 'chip-ended', { active: activeFilter === ENDED_FILTER }]"
             @click="selectFilter(ENDED_FILTER)"
           >
-            🪦 {{ $t("filters.status.ended") }}
+            <span aria-hidden="true">🪦</span> {{ $t("filters.status.ended") }}
             <span class="count">{{ count(ENDED_FILTER) }}</span>
           </button>
         </div>
@@ -201,7 +201,7 @@ function count(tag: string): number {
         :class="['card', { 'is-ended': item.ended }]"
       >
         <span v-if="item.ended" class="ended-badge">
-          🪦 {{ $t("filters.badge.ended") }}
+          <span aria-hidden="true">🪦</span> {{ $t("filters.badge.ended") }}
           <span class="ended-date">{{ item.ended }}</span>
         </span>
         <header class="card-header">
@@ -345,7 +345,7 @@ function count(tag: string): number {
 
 /* Discontinued services: gently faded, with a cute tombstone badge. */
 .card.is-ended {
-  background: light-dark(#fbf7f9, #221c20);
+  background: var(--ended-bg);
   border-style: dashed;
 }
 
@@ -376,12 +376,12 @@ function count(tag: string): number {
   font-size: 0.72rem;
   font-weight: bold;
   letter-spacing: 0.02em;
-  color: light-dark(#8a3b63, #ffd9e8);
-  background: light-dark(#ffe3ef, #4a2438);
-  border: 1.5px solid light-dark(#e58bb0, #b56c8c);
+  color: var(--ended-badge-text);
+  background: var(--ended-badge-bg);
+  border: 1.5px solid var(--ended-badge-border);
   border-radius: 999px;
   transform: rotate(4deg);
-  box-shadow: 1px 1px 0 light-dark(#e58bb0, #00000055);
+  box-shadow: 1px 1px 0 var(--ended-badge-shadow);
 }
 
 .ended-badge .ended-date {
@@ -390,9 +390,9 @@ function count(tag: string): number {
 }
 
 .filter-chip.chip-ended.active {
-  background: light-dark(#e58bb0, #b56c8c);
+  background: var(--ended-badge-border);
   color: #fff;
-  box-shadow: 2px 2px 0px light-dark(#8a3b63, #4a2438);
+  box-shadow: 2px 2px 0px var(--ended-badge-text);
 }
 
 .card:hover {

--- a/src/components/Birth.vue
+++ b/src/components/Birth.vue
@@ -4,10 +4,16 @@ import { useI18n } from "vue-i18n"
 import {
   items as allItems,
   countByTag,
+  countEnded,
   filterByTag,
+  filterEnded,
   searchByKeyword,
   sortByDate,
 } from "@/lib/items"
+
+// Sentinel filter value for the "discontinued" chip — `ended` lives outside the
+// `type` array, so it can't go through filterByTag like the other filters.
+const ENDED_FILTER = "__ended__"
 
 const TYPE_FILTERS = [
   "All",
@@ -84,8 +90,11 @@ const publicPath = import.meta.env.BASE_URL
 const sortedItems = sortByDate(allItems)
 
 const filteredItems = computed(() => {
-  const tagged = filterByTag(sortedItems, activeFilter.value)
-  return searchByKeyword(tagged, keyword.value)
+  const base =
+    activeFilter.value === ENDED_FILTER
+      ? filterEnded(sortedItems)
+      : filterByTag(sortedItems, activeFilter.value)
+  return searchByKeyword(base, keyword.value)
 })
 
 function selectFilter(filter: string) {
@@ -93,7 +102,7 @@ function selectFilter(filter: string) {
 }
 
 function count(tag: string): number {
-  return countByTag(allItems, tag)
+  return tag === ENDED_FILTER ? countEnded(allItems) : countByTag(allItems, tag)
 }
 </script>
 
@@ -166,10 +175,35 @@ function count(tag: string): number {
           </button>
         </div>
       </div>
+
+      <div class="filter-group">
+        <h2 id="filter-label-status" class="filter-label">
+          {{ $t("filters.label.status") }}
+        </h2>
+        <div class="filter-scroll" role="group" aria-labelledby="filter-label-status">
+          <button
+            type="button"
+            :aria-pressed="activeFilter === ENDED_FILTER"
+            :class="['filter-chip', 'chip-ended', { active: activeFilter === ENDED_FILTER }]"
+            @click="selectFilter(ENDED_FILTER)"
+          >
+            🪦 {{ $t("filters.status.ended") }}
+            <span class="count">{{ count(ENDED_FILTER) }}</span>
+          </button>
+        </div>
+      </div>
     </section>
 
     <section class="grid-container" aria-label="Timeline">
-      <article v-for="item in filteredItems" :key="item.name" class="card">
+      <article
+        v-for="item in filteredItems"
+        :key="item.name"
+        :class="['card', { 'is-ended': item.ended }]"
+      >
+        <span v-if="item.ended" class="ended-badge">
+          🪦 {{ $t("filters.badge.ended") }}
+          <span class="ended-date">{{ item.ended }}</span>
+        </span>
         <header class="card-header">
           <span class="date">{{ item.date }}</span>
           <img
@@ -298,6 +332,7 @@ function count(tag: string): number {
 }
 
 .card {
+  position: relative;
   border: var(--border-width) solid var(--text-color);
   border-radius: var(--border-radius);
   padding: 1.5rem;
@@ -306,6 +341,58 @@ function count(tag: string): number {
   transition: all 0.2s ease;
   display: flex;
   flex-direction: column;
+}
+
+/* Discontinued services: gently faded, with a cute tombstone badge. */
+.card.is-ended {
+  background: light-dark(#fbf7f9, #221c20);
+  border-style: dashed;
+}
+
+.card.is-ended .logo {
+  filter: grayscale(1);
+  opacity: 0.5;
+  transition: filter 0.2s ease, opacity 0.2s ease;
+}
+
+.card.is-ended:hover .logo {
+  filter: grayscale(0);
+  opacity: 1;
+}
+
+.card.is-ended .name {
+  color: var(--muted-color);
+}
+
+.ended-badge {
+  position: absolute;
+  top: -0.7rem;
+  right: -0.5rem;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.2rem 0.6rem;
+  font-size: 0.72rem;
+  font-weight: bold;
+  letter-spacing: 0.02em;
+  color: light-dark(#8a3b63, #ffd9e8);
+  background: light-dark(#ffe3ef, #4a2438);
+  border: 1.5px solid light-dark(#e58bb0, #b56c8c);
+  border-radius: 999px;
+  transform: rotate(4deg);
+  box-shadow: 1px 1px 0 light-dark(#e58bb0, #00000055);
+}
+
+.ended-badge .ended-date {
+  font-weight: normal;
+  opacity: 0.75;
+}
+
+.filter-chip.chip-ended.active {
+  background: light-dark(#e58bb0, #b56c8c);
+  color: #fff;
+  box-shadow: 2px 2px 0px light-dark(#8a3b63, #4a2438);
 }
 
 .card:hover {

--- a/src/components/Birth.vue
+++ b/src/components/Birth.vue
@@ -101,8 +101,11 @@ function selectFilter(filter: string) {
   activeFilter.value = activeFilter.value === filter ? "All" : filter
 }
 
-function count(tag: string): number {
-  return tag === ENDED_FILTER ? countEnded(allItems) : countByTag(allItems, tag)
+// Counts are over the full, constant dataset, so they never change — compute
+// them once instead of re-running countByTag on every render inside v-for.
+const counts: Record<string, number> = { [ENDED_FILTER]: countEnded(allItems) }
+for (const filter of [...TYPE_FILTERS, ...NATIONALITY_FILTERS, ...ERA_FILTERS]) {
+  counts[filter] = countByTag(allItems, filter)
 }
 </script>
 
@@ -133,7 +136,7 @@ function count(tag: string): number {
             @click="selectFilter(filter)"
           >
             {{ $t(`filters.types.${filter}`) }}
-            <span class="count">{{ count(filter) }}</span>
+            <span class="count">{{ counts[filter] }}</span>
           </button>
         </div>
       </div>
@@ -152,7 +155,7 @@ function count(tag: string): number {
             @click="selectFilter(filter)"
           >
             {{ $t(`filters.nationalities.${filter}`) }}
-            <span class="count">{{ count(filter) }}</span>
+            <span class="count">{{ counts[filter] }}</span>
           </button>
         </div>
       </div>
@@ -171,7 +174,7 @@ function count(tag: string): number {
             @click="selectFilter(filter)"
           >
             {{ $t(`filters.eras.${filter}`) }}
-            <span class="count">{{ count(filter) }}</span>
+            <span class="count">{{ counts[filter] }}</span>
           </button>
         </div>
       </div>
@@ -188,7 +191,7 @@ function count(tag: string): number {
             @click="selectFilter(ENDED_FILTER)"
           >
             <span aria-hidden="true">🪦</span> {{ $t("filters.status.ended") }}
-            <span class="count">{{ count(ENDED_FILTER) }}</span>
+            <span class="count">{{ counts[ENDED_FILTER] }}</span>
           </button>
         </div>
       </div>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -17,6 +17,7 @@ const en = {
       category: "Category",
       nationality: "Nationality",
       era: "Era",
+      status: "Status",
     },
     types: {
       All: "All",
@@ -87,6 +88,12 @@ const en = {
       大正: "1912-1926",
       明治: "1868-1912",
     },
+    status: {
+      ended: "Discontinued",
+    },
+    badge: {
+      ended: "R.I.P.",
+    },
   },
 }
 
@@ -109,6 +116,7 @@ const ja: MessageSchema = {
       category: "カテゴリ",
       nationality: "国",
       era: "元号",
+      status: "状態",
     },
     types: {
       All: "すべて",
@@ -178,6 +186,12 @@ const ja: MessageSchema = {
       昭和: "昭和",
       大正: "大正",
       明治: "明治",
+    },
+    status: {
+      ended: "サービス終了",
+    },
+    badge: {
+      ended: "R.I.P.",
     },
   },
 }

--- a/src/lib/items.ts
+++ b/src/lib/items.ts
@@ -36,7 +36,7 @@ export function filterEnded(items: readonly Item[]): Item[] {
 }
 
 export function countEnded(items: readonly Item[]): number {
-  return items.filter((item) => item.ended != null).length
+  return items.reduce((acc, item) => (item.ended != null ? acc + 1 : acc), 0)
 }
 
 export function sortByDate(items: readonly Item[]): Item[] {

--- a/src/lib/items.ts
+++ b/src/lib/items.ts
@@ -10,6 +10,7 @@ export interface Item {
   readonly nationality: string
   readonly description: string
   readonly description_en: string
+  readonly ended?: string
 }
 
 export const items: readonly Item[] = data as readonly Item[]
@@ -28,6 +29,14 @@ export function searchByKeyword(items: readonly Item[], keyword: string): Item[]
 export function filterByTag(items: readonly Item[], tag: string): Item[] {
   if (tag === "" || tag === "All") return [...items]
   return items.filter((item) => item.type.includes(tag))
+}
+
+export function filterEnded(items: readonly Item[]): Item[] {
+  return items.filter((item) => item.ended != null)
+}
+
+export function countEnded(items: readonly Item[]): number {
+  return items.filter((item) => item.ended != null).length
 }
 
 export function sortByDate(items: readonly Item[]): Item[] {


### PR DESCRIPTION
## Summary

Mark discontinued services with a "shut down" indicator (tombstone badge + shutdown date + faded styling), plus a Status filter to list them. Includes a full audit of all 281 entries so the marker isn't applied piecemeal.

## Feature

- **Data** Optional `ended` field (ISO shutdown date) on `info.json` entries; live services don't carry it.
- **Types / logic** `ended?: string` on `Item`, plus `filterEnded` / `countEnded` helpers in `src/lib/items.ts`.
- **UI** `Birth.vue` — discontinued cards get a 🪦 R.I.P. badge with the shutdown date, a grayscaled + faded logo (restored on hover), and a dashed border. A new "Status" filter group lists them. Since `ended` lives outside the `type` array, its filter branches through an `ENDED_FILTER` sentinel instead of `filterByTag`.
- **i18n** Labels under both `en` and `ja` (satisfies the `MessageSchema` constraint).
- **Script** `scripts/mark-ended.mjs` (idempotent) seeds the dates.

## Audit — 22 services marked

Swept all 281 entries; every shutdown date verified against primary sources.

- **Web services / companies:** Google Reader (2013-07-01), Google+ (2019-04-02), Google Wave (2012-04-30), Vine (2017-01-17), GeoCities (2009-10-26), Friendster (2015-06-30), SixDegrees.com (2001), Skype (2025-05-05), Stadia (2023-01-18), Alexa Internet (2022-05-01), Pandora TV (2023-01-31), LiveLeak (2021-05-05), Theranos (2018-09-04), Mt. Gox (2014-02-28), Sora (2026-04-26)
- **Piracy / dark web:** Mangamura (2018-04-17), Megaupload (2012-01-19), LimeWire (2010-10-26), Napster (2001-07-11), Popcorn Time (2022-01-05), Silk Road (2013-10-02), AlphaBay (2017-07-04)

**Deliberately excluded:** brand rebrands (Bard → Gemini), corporate acquisitions where the product lives on (Sun → Oracle), still-operating but shrunken apps (Clubhouse, Myspace), and security incidents / malware (not services).

## Verification

- `pnpm typecheck` OK
- `pnpm test` 18/18 pass
- `pnpm lint` clean
- `pnpm build` succeeds
