### PR TITLE
chore(deps): ignore typescript major bumps until vue-tsc supports TS 7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
       time: "06:00"
       timezone: "Asia/Tokyo"
     open-pull-requests-limit: 10
+    ignore:
+      # vue-tsc still requires typescript/lib/tsc, which TS 7 dropped from its
+      # package exports. Unpin once vue-tsc supports TS 7.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       vue-ecosystem:
         patterns:


### PR DESCRIPTION
PR #62's Typecheck job was failing because the build-tooling group picked up the TypeScript 6→7 major bump.

TS 7 (the native port) removed `typescript/lib/tsc` from its package exports, but vue-tsc 3.3.7 still requires that subpath, so `vue-tsc -b --noEmit` dies at startup:

```text
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './lib/tsc' is not defined
by "exports" in .../typescript@7.0.2/package.json
```

This tells Dependabot to stop proposing TypeScript major bumps. Drop the ignore rule once vue-tsc supports TS 7.

After merging this, comment `@dependabot recreate` on #62 and it will rebuild the group without TypeScript — the remaining 5 bumps (biome / vite / vitest / vue-tsc / @types/node) should pass CI.