### PR TITLE
ci: add a Claude review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,98 @@
+name: Claude review
+
+# CI answers "does it build and do the tests pass". This asks the question no
+# script here can. It reviews, it does not gate: nothing here is a required
+# check.
+#
+# The action refuses to run when this file differs from the copy on the default
+# branch, so a pull request cannot rewrite its own reviewer. The cost is that
+# any change to this file, including the one that added it, goes unreviewed by
+# Claude until it is merged.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions: {}
+
+# One review per pull request. A rapid re-push cancels the run it superseded
+# rather than paying for a review of a diff that no longer exists.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    # A pull request from a fork gets no secrets, so the job would fail on
+    # authentication rather than say anything useful. Drafts are skipped until
+    # they are marked ready, which is what the ready_for_review trigger is for.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      pull-requests: write
+      # Required by the action's default GitHub App authentication.
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      # Without the secret the action exits successfully having reviewed
+      # nothing, which is worse than failing: the check goes green and the
+      # pull request looks reviewed. Fail here instead, where the reason is
+      # legible.
+      - name: Require the token
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+            echo "::error::CLAUDE_CODE_OAUTH_TOKEN is not set. Generate one with 'claude setup-token', then: gh secret set CLAUDE_CODE_OAUTH_TOKEN"
+            exit 1
+          fi
+
+      - uses: anthropics/claude-code-action@6b082c41935b4c8a3b8b0ef85ba4ba4d9eeb8975 # v1
+        with:
+          # A subscription token, not an API key: runs against the Claude plan
+          # instead of API credits. Generate it with `claude setup-token`.
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR: ${{ github.event.pull_request.number }}
+
+            This is a visual timeline of IT history: founding dates and origins of companies,
+            services, languages, tools, AI models and security incidents, driven by
+            info.json.
+
+            Do not repeat what CI already does. The build runs on this PR already.
+
+            Look for what only a reader can catch:
+
+            1. Dates and facts. A founding date, a rename, an acquisition or a shutdown is
+               the entire product here. A claim without a source, or one that contradicts a
+               neighbouring entry, is the defect that matters.
+
+            2. The lists staying in sync. An entry added in one place has to appear
+               everywhere the data model expects it, or it renders as a gap rather than
+               failing loudly.
+
+            3. Schema consistency. A missing or extra field, a category that no other entry
+               uses, or a tag that does not match the existing vocabulary.
+
+            4. Duplicates and near-duplicates, particularly the same company under a former
+               name.
+
+            5. Assets. A logo that is white-on-transparent disappears against a light
+               background, and an oversized image on a timeline that loads everything at
+               once is felt immediately.
+
+            Post findings as inline comments on the lines they concern. Use one
+            top-level comment for the summary. Be specific and cite
+            `file:line`. If the diff is clean against all of the above, say so
+            in one line rather than manufacturing nits.
+
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
Adds an automatic Claude review on every pull request.

## Shape

Same as the one in `kanywst/aws-bill-explained`, which is the most recently revised version in the account. Actions pinned by commit SHA rather than tag, since a moved tag would swap the code that runs with a token in scope. `permissions: {}` at the workflow level and granted per job. Fork pull requests skipped, because they get no secrets and could only fail on authentication. Drafts skipped until marked ready. A timeout, so a stuck review cannot hold a runner.

A missing token fails loudly rather than skipping quietly: a skipped job goes green, which makes a pull request look reviewed when nothing read it.

## The prompt is written for this repo

This is a visual timeline of IT history: founding dates and origins of companies, services, languages, tools, AI models and security incidents, driven by info.json. Do not repeat what CI already does. The build runs on this PR already.\n\nLook for what only a reader can catch:

1. Dates and facts. A founding date, a rename, an acquisition or a shutdown is
   the entire product here. A claim without a source, or one that contradicts a
   neighbouring entry, is the defect that matters.

2. The lists staying in sync. An entry added in one place has to appear
   everywhere the data model expects it, or it renders as a gap rather than
   failing loudly.

3. Schema consistency. A missing or extra field, a category that no other entry
   uses, or a tag that does not match the existing vocabulary.

4. Duplicates and near-duplicates, particularly the same company under a former
   name.

5. Assets. A logo that is white-on-transparent disappears against a light
   background, and an oversized image on a timeline that loads everything at
   once is felt immediately.

## Before it does anything

`CLAUDE_CODE_OAUTH_TOKEN` has to be set on this repo, generated with `claude setup-token`. It is a subscription token rather than an API key, which is why it goes through `claude_code_oauth_token`. The check is advisory and not required, so it does not block a merge.

`yamllint` and `actionlint` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated code reviews for eligible pull requests.
  * Reviews can identify factual, schema, synchronization, duplication, and asset issues.
  * Findings are shared through inline comments and summary feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->