### PR TITLE
ci: skip the Claude review on Dependabot pull requests

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -26,9 +26,15 @@ jobs:
     # A pull request from a fork gets no secrets, so the job would fail on
     # authentication rather than say anything useful. Drafts are skipped until
     # they are marked ready, which is what the ready_for_review trigger is for.
+    #
+    # Dependabot is skipped for the same reason a fork is: its runs read from a
+    # separate secret store, so CLAUDE_CODE_OAUTH_TOKEN is empty and the job
+    # fails on the token check every Monday. Nothing is lost — a dependency
+    # bump has no dates, no entries and no logos to check.
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.draft == false
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:


### PR DESCRIPTION
The `review` job fails on every Dependabot pull request (#76, #77, #78) at the `Require the token` step, four seconds in.

Dependabot-triggered runs read from a separate secret store — the run log says `Secret source: Dependabot` — and `CLAUDE_CODE_OAUTH_TOKEN` only exists as a repository secret, so it resolves to an empty string and the guard exits 1 as designed.

Two ways out: mirror the token into the Dependabot secret store, or skip the job. Skipping wins — a lockfile diff has no dates, no entries and no logos, which is everything the review prompt looks for. Adding the secret would spend plan usage every Monday to be told the diff is clean.

Adds `github.event.pull_request.user.login != 'dependabot[bot]'` to the job's `if`, alongside the existing fork and draft guards, which skip for the same reason. The check reports as skipped rather than failed.

`review` is not a required check, so this was never blocking a merge — the three open bump PRs are all `MERGEABLE`. It was only noise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated code reviews now skip dependency update pull requests.
  * Existing checks for forked and draft pull requests remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->